### PR TITLE
Product new→createフォームサムネイル削除機能修復

### DIFF
--- a/app/assets/javascripts/product_create.js
+++ b/app/assets/javascripts/product_create.js
@@ -257,7 +257,7 @@ $(document).on('turbolinks:load', function(){
             id = "hiddenCount${labelIndex}"
             class = "hiddenCount">
           <div class="btn-box">
-            <a href="" class="added-img-delete-btn, img-edit-btn">編集</a>
+            <a href="" class="img-edit-btn">編集</a>
             <a href="" class="img-delete-btn">削除</a>
           </div>
         </div>
@@ -279,7 +279,7 @@ $(document).on('turbolinks:load', function(){
 
   });
 
-  //削除ボタンを押した時の処理///////修理要//////
+  //削除ボタンを押した時の処理
   $('.create-dropbox__label').on('click', '.added-img-delete-btn', function(e) {//なぜ$()->$(document)だといけたのか未理解
     e.preventDefault();
     let btnBox =e.target.closest('.btn-box');

--- a/app/assets/javascripts/product_create.js
+++ b/app/assets/javascripts/product_create.js
@@ -47,58 +47,7 @@ $(document).on('turbolinks:load', function(){
         <option value="ゆうパケット">ゆうパケット</option></select>
       </div>
     </div>`
-  //hidden属性で送られるcountの値を今あるimgの連番で振り直し（途中のイメージを削除された時のため）
-  //画像が何枚あるか何枚目かはこの値で管理
-  function overwriteHiddenCountAll(){
-    let count = 1;
-    $('.hiddenCount').each(function(){
-      $(this).attr('value', count);
-      count = count + 1;
-    });
-  }
-  //次の画像のインデックスとしてlabelタグのForに入れるべき番号を取得する
-  //（はずだったが他の処理も一部まとめた
-  //"画像枚数が変化する(しようとする)際の処理"としてまとめた方がいいかもしれない）
-  function youngestInputIndex(){
-    //サムネイルとセットのhiddenCount要素を全て取得
-    let allImgs = $('.hiddenCount');
-    let nextIndex = $(allImgs).length;
-    //10ならば最大枚数アップ済、labelが機能しなくなる値""を返す
-    if (nextIndex == 10){
-      return "";//
-    }
-    //0ならばプレースホルダを再表示し0を返す
-    //最後の1枚削除によりアップローダーが空になった場合
-    else if(nextIndex ==0){
-      $('.dropbox__placeholder').show();
-      return nextIndex;
-    }
-    //この時点でnextIndexは返り値の取りうる最大値
-    //Whileを最大値->0へと回しinputが空白だったもので一番小さな値にセット
-    let inputTagCounter = nextIndex;
-      while(0 <= inputTagCounter){
-        //hidden要素にはidに`hiddenCount${inputのインデックス番号}`が付けられている
-        let filledInputSelecter = "#hiddenCount" + inputTagCounter;
-          //lengthメソッドの返り値が0なら要素が存在しない
-        if ($(filledInputSelecter).length ==0){
-          //サムネイルの無い番号だったならその値へ更新
-          nextIndex = inputTagCounter;
-        }
-        inputTagCounter = inputTagCounter -1;
-      }
-    return nextIndex;
-  }
-  //labelのfor属性内の数値を返す、他所でも起動しているらしくDOMセレクタ見直し
-  //応急処置（たぶん）
-  function readLabelIndexCreate(){
-    let labelIndex = $('label').attr('for').replace(/[^0-9]/g, '');//数字でない部分を空白へ置換=削除
-    labelIndex = Number(labelIndex);//数値型へ変換
-    return labelIndex;
-  }
-  function overwriteLabel(inputIndex){
-    let updatedFor = 'product_product_images_attributes_'+inputIndex+'_product_image';
-    $("[for ^='product_product_images_attributes_']").attr('for', updatedFor);
-  }
+
   //カテゴリーセレクトボックス関連処理
   //ct_no_1＝親カテゴリ、ct_no_2＝子カテゴリ、ct_no_3＝孫カテゴリ
   $(document).on("change", "#category_parent", function() {
@@ -224,76 +173,6 @@ $(document).on('turbolinks:load', function(){
     }
   });
   //カテゴリーセレクトボックス関連処理ここまで
-  
-  //////ここからイメージボックス関連
-  let labelIndex = readLabelIndexCreate(); //new.html.hamlで定義される"0"
-  $('.image-form').on('change', 'input[type="file"]', function(e) {
-    //inputタグのインデックスを取得する
-    labelIndex = readLabelIndexCreate();
-    // 11枚目なら中断
-    if(labelIndex >= 10){//inputタグで検出するのでダイアログは表示される
-      return false;
-    }
-    let file = e.target.files[0];
-    // 画像ファイル以外なら中断
-    if(file.type.indexOf("image") < 0){
-      return false;
-    }
-
-    //ファイルリーダーがファイルを読み終わったら行うサムネイル生成などの関連処理
-    //(関数として切り出すとサムネイルが表示されなくなったため保留//
-    //e.target.resultを変数に代入もできないためそのあたりの影響とかんがえられる)
-    let reader = new FileReader();
-    // let changedInput = $(e.target);
-    //を付与
-    reader.onload = function (e){
-      let imageThumbnail =`
-        <div class="product-img-box">
-          <img src="${e.target.result}" width="114px" height="116px" 
-            class="thumbnail" title="${file.name}" >
-          <input type="hidden" 
-            name="product[product_images_attributes][${labelIndex}][count]" 
-            value="${labelIndex}"
-            id = "hiddenCount${labelIndex}"
-            class = "hiddenCount">
-          <div class="btn-box">
-            <a href="" class="img-edit-btn">編集</a>
-            <a href="" class="img-delete-btn">削除</a>
-          </div>
-        </div>
-        `;
-      $('.create-dropbox__label').before(imageThumbnail);
-      $('.create-dropbox__label').ready(function(){ //  この記述でDOM要素読み込まれるまで待つらしい
-        //次のchangeイベントでのinputタグ(product_model)を更新
-        labelIndex = youngestInputIndex();
-        overwriteLabel(labelIndex);
-        overwriteHiddenCountAll();
-        //プレースホルダ非表示
-        $('.dropbox__placeholder').hide();
-        
-      });
-    };
-    ///ファイル読み込み 上記サムネイル・編集削除ボタン・count値のhidden input生成等が行われる
-    reader.readAsDataURL(file);
-    //サムネイルと編集削除ボタン生成ここまで//
-
-  });
-
-  //削除ボタンを押した時の処理
-  $('.create-dropbox__label').on('click', '.added-img-delete-btn', function(e) {//なぜ$()->$(document)だといけたのか未理解
-    e.preventDefault();
-    let btnBox =e.target.closest('.btn-box');
-    let inputHidden =$(btnBox).prev();
-    let imgThumbnail = $(inputHidden).prev();
-    let inputFile = $(inputHidden).prev();
-    $(inputFile).val(null); // TODO:アップロードされたファイルの削除 countをnull許可にすると途中で削除した画像も保存されてしまう
-    $(imgThumbnail).remove();
-    $(inputHidden).remove();
-    $(btnBox).remove();
-    labelIndex = youngestInputIndex();
-    overwriteLabel(labelIndex);
-    overwriteHiddenCountAll();
-  });
 
   $('#product_delivery_fee').change(function() {
     $('#product_delivery_method').remove();

--- a/app/assets/javascripts/product_create.js
+++ b/app/assets/javascripts/product_create.js
@@ -257,7 +257,7 @@ $(document).on('turbolinks:load', function(){
             id = "hiddenCount${labelIndex}"
             class = "hiddenCount">
           <div class="btn-box">
-            <a href="" class="img-edit-btn">編集</a>
+            <a href="" class="added-img-delete-btn, img-edit-btn">編集</a>
             <a href="" class="img-delete-btn">削除</a>
           </div>
         </div>

--- a/app/assets/javascripts/product_edit.js
+++ b/app/assets/javascripts/product_edit.js
@@ -156,7 +156,7 @@ $(document).on('turbolinks:load', function(){
 
 
   
-  // editフォームからは実行されない
+  // createフォームからは実行されない
   pathSelf =location.pathname;
   if (pathSelf.match(/create/) != null) {
       return false;
@@ -296,9 +296,9 @@ $(document).on('turbolinks:load', function(){
           value="${labelIndex}"
           id = "hiddenCount${labelIndex}"
           class = "hiddenCount">
-        <div class="btn-box">
-          <a href="" class="img-edit-btn">編集</div>
-          <a href="" class="added-img-delete-btn">削除</div>
+        <div class="thumbnail__sub">
+          <div class= class="thumbnail__sub__btn">編集</div>
+          <div class= class="exist-img-delete-btn thumbnail__sub__btn">削除</div>
         </div>
         `;
       $(changedInput).after(imageThumbnail);
@@ -323,11 +323,11 @@ $(document).on('turbolinks:load', function(){
   $(document).on('click', '.exist-img-delete-btn', function(e) {//なぜ$()->$(document)だといけたのか未理解
     e.preventDefault();
   //（画像が残り一枚なら機能しなくするif必要）
-    if ($(this).closest('.btn-box').prev('[name *="destroy"]').attr('value') == 0){
-      $(this).closest('.btn-box').prev('[name *="destroy"]').attr({'value': 1});
+    if ($(this).closest('.thumbnail__sub').prev('[name *="destroy"]').attr('value') == 0){
+      $(this).closest('.thumbnail__sub').prev('[name *="destroy"]').attr({'value': 1});
       $(this).closest('.product-img-box.exist-img').find('img').css('opacity', '0.5');
     }else{
-      $(this).closest('.btn-box').prev('[name *="destroy"]').attr({'value': 0});
+      $(this).closest('.thumbnail__sub').prev('[name *="destroy"]').attr({'value': 0});
       $(this).closest('.product-img-box.exist-img').find('img').css('opacity', '1');
     }
   });

--- a/app/assets/javascripts/product_edit.js
+++ b/app/assets/javascripts/product_edit.js
@@ -298,7 +298,7 @@ $(document).on('turbolinks:load', function(){
           class = "hiddenCount">
         <div class="btn-box">
           <a href="" class="img-edit-btn">編集</div>
-          <a href="" class="img-delete-btn">削除</div>
+          <a href="" class="added-img-delete-btn">削除</div>
         </div>
         `;
       $(changedInput).after(imageThumbnail);
@@ -320,7 +320,7 @@ $(document).on('turbolinks:load', function(){
 
   //既存画像の削除ボタンがクリックされた時の処理
   $(document).off('click');//イベント多重化防止
-  $(document).on('click', '.img-delete-btn', function(e) {//なぜ$()->$(document)だといけたのか未理解
+  $(document).on('click', '.exist-img-delete-btn', function(e) {//なぜ$()->$(document)だといけたのか未理解
     e.preventDefault();
   //（画像が残り一枚なら機能しなくするif必要）
     if ($(this).closest('.btn-box').prev('[name *="destroy"]').attr('value') == 0){

--- a/app/assets/javascripts/product_form_img.js
+++ b/app/assets/javascripts/product_form_img.js
@@ -15,6 +15,12 @@ $(document).on('turbolinks:load', function(){
     labelIndex = Number(labelIndex);//数値型へ変換
     return labelIndex;
   }
+  //サムネイルから空にするべきinputのindexを読み取る
+  function returnfileInputName(productImgBox){
+    let fileInputName = $(productImgBox).find('.hiddenCount').attr('name').replace(/count/g, 'product_image');//数字でない部分を空白へ置換=削除
+
+    return fileInputName;
+  }
   function overwriteLabel(inputIndex){
     let updatedFor = 'product_product_images_attributes_'+inputIndex+'_product_image';
     $("[for ^='product_product_images_attributes_']").attr('for', updatedFor);
@@ -107,19 +113,16 @@ $(document).on('turbolinks:load', function(){
 
   });
 
-  //削除ボタンを押した時の処理///////発火しない、原因がわからない修理要//////
+  //削除ボタンを押した時の処理
   $(document).off('click');
   $(document).on('click', '.added-img-delete-btn', function(e) {//なぜ$()->$(document)だといけたのか未理解
     console.log('added-img-delete-btn was clicked');
     e.preventDefault();
-    let btnBox =e.target.closest('.thumbnail__sub');
-    let inputHidden =$(btnBox).prev();
-    let imgThumbnail = $(inputHidden).prev();
-    let inputFile = $(inputHidden).prev();
-    $(inputFile).val(null); // TODO:アップロードされたファイルの削除 countをnull許可にすると途中で削除した画像も保存されてしまう
-    $(imgThumbnail).remove();
-    $(inputHidden).remove();
-    $(btnBox).remove();
+    let productImgBox =e.target.closest('.added-img');
+    let fileInputName = returnfileInputName(productImgBox);
+    let fleinputSelecter = '[name="'+ fileInputName + '"]';
+    $(fleinputSelecter).val(null);// TODO:アップロードされたファイルの削除 countをnull許可にすると途中で削除した画像も保存されてしまう
+    $(productImgBox).remove();
     labelIndex = youngestInputIndex();
     overwriteLabel(labelIndex);
     overwriteHiddenCountAll();

--- a/app/assets/javascripts/product_form_img.js
+++ b/app/assets/javascripts/product_form_img.js
@@ -1,11 +1,6 @@
-$(function(){
+$(document).on('turbolinks:load', function(){
   console.log('form');
-  // editフォームからは実行されない
-  pathSelf =location.pathname;
-  if (pathSelf.match(/edit/) != null) {
-      return false;
-  }
-  //hidden属性で送られるcountの値を今あるimgの連番で振り直し（途中のイメージを削除された時のため）
+    //hidden属性で送られるcountの値を今あるimgの連番で振り直し（途中のイメージを削除された時のため）
   //画像が何枚あるか何枚目かはこの値で管理
   function overwriteHiddenCountAll(){
     let count = 1;
@@ -13,6 +8,16 @@ $(function(){
       $(this).attr('value', count);
       count = count + 1;
     });
+  }
+  //labelのfor属性内の数値を返す、他所でも起動しているらしくDOMセレクタ見直し//応急処置（たぶん）
+  function readLabelIndexCreate(){
+    let labelIndex = $('label').attr('for').replace(/[^0-9]/g, '');//数字でない部分を空白へ置換=削除
+    labelIndex = Number(labelIndex);//数値型へ変換
+    return labelIndex;
+  }
+  function overwriteLabel(inputIndex){
+    let updatedFor = 'product_product_images_attributes_'+inputIndex+'_product_image';
+    $("[for ^='product_product_images_attributes_']").attr('for', updatedFor);
   }
   //次の画像のインデックスとしてlabelタグのForに入れるべき番号を取得する
   //（はずだったが他の処理も一部まとめた
@@ -46,34 +51,9 @@ $(function(){
       }
     return nextIndex;
   }
-  //labelのfor属性内の数値を返す、他所でも起動しているらしくDOMセレクタ見直し
-  //応急処置（たぶん）
-  function readLabelIndexCreate(){
-    let labelIndex = $('label').attr('for').replace(/[^0-9]/g, '');//数字でない部分を空白へ置換=削除
-    labelIndex = Number(labelIndex);//数値型へ変換
-    return labelIndex;
-  }
-  function overwriteLabel(inputIndex){
-    let updatedFor = 'product_product_images_attributes_'+inputIndex+'_product_image';
-    $("[for ^='product_product_images_attributes_']").attr('for', updatedFor);
-  }
-  //削除ボタンを押した時の処理///////発火しない、原因がわからない修理要//////
-  $(document).off('click');
-  $(document).on('click', '.added-img-delete-btn', function(e) {//なぜ$()->$(document)だといけたのか未理解
-    console.log('added-img-delete-btn was clicked');
-    e.preventDefault();
-    let btnBox =e.target.closest('.thumbnail__sub');
-    let inputHidden =$(btnBox).prev();
-    let imgThumbnail = $(inputHidden).prev();
-    let inputFile = $(inputHidden).prev();
-    $(inputFile).val(null); // TODO:アップロードされたファイルの削除 countをnull許可にすると途中で削除した画像も保存されてしまう
-    $(imgThumbnail).remove();
-    $(inputHidden).remove();
-    $(btnBox).remove();
-    labelIndex = youngestInputIndex();
-    overwriteLabel(labelIndex);
-    overwriteHiddenCountAll();
-  });
+
+  ///////////////////////
+  //////ここから画像選択本体
   let labelIndex = readLabelIndexCreate(); //new.html.hamlで定義される"0"
   $('.image-form').on('change', 'input[type="file"]', function(e) {
     //inputタグのインデックスを取得する
@@ -125,5 +105,23 @@ $(function(){
     reader.readAsDataURL(file);
     //サムネイルと編集削除ボタン生成ここまで//
 
+  });
+
+  //削除ボタンを押した時の処理///////発火しない、原因がわからない修理要//////
+  $(document).off('click');
+  $(document).on('click', '.added-img-delete-btn', function(e) {//なぜ$()->$(document)だといけたのか未理解
+    console.log('added-img-delete-btn was clicked');
+    e.preventDefault();
+    let btnBox =e.target.closest('.thumbnail__sub');
+    let inputHidden =$(btnBox).prev();
+    let imgThumbnail = $(inputHidden).prev();
+    let inputFile = $(inputHidden).prev();
+    $(inputFile).val(null); // TODO:アップロードされたファイルの削除 countをnull許可にすると途中で削除した画像も保存されてしまう
+    $(imgThumbnail).remove();
+    $(inputHidden).remove();
+    $(btnBox).remove();
+    labelIndex = youngestInputIndex();
+    overwriteLabel(labelIndex);
+    overwriteHiddenCountAll();
   });
 });

--- a/app/assets/javascripts/product_form_img.js
+++ b/app/assets/javascripts/product_form_img.js
@@ -1,0 +1,129 @@
+$(function(){
+  console.log('form');
+  // editフォームからは実行されない
+  pathSelf =location.pathname;
+  if (pathSelf.match(/edit/) != null) {
+      return false;
+  }
+  //hidden属性で送られるcountの値を今あるimgの連番で振り直し（途中のイメージを削除された時のため）
+  //画像が何枚あるか何枚目かはこの値で管理
+  function overwriteHiddenCountAll(){
+    let count = 1;
+    $('.hiddenCount').each(function(){
+      $(this).attr('value', count);
+      count = count + 1;
+    });
+  }
+  //次の画像のインデックスとしてlabelタグのForに入れるべき番号を取得する
+  //（はずだったが他の処理も一部まとめた
+  //"画像枚数が変化する(しようとする)際の処理"としてまとめた方がいいかもしれない）
+  function youngestInputIndex(){
+    //サムネイルとセットのhiddenCount要素を全て取得
+    let allImgs = $('.hiddenCount');
+    let nextIndex = $(allImgs).length;
+    //10ならば最大枚数アップ済、labelが機能しなくなる値""を返す
+    if (nextIndex == 10){
+      return "";//
+    }
+    //0ならばプレースホルダを再表示し0を返す
+    //最後の1枚削除によりアップローダーが空になった場合
+    else if(nextIndex ==0){
+      $('.dropbox__placeholder').show();
+      return nextIndex;
+    }
+    //この時点でnextIndexは返り値の取りうる最大値
+    //Whileを最大値->0へと回しinputが空白だったもので一番小さな値にセット
+    let inputTagCounter = nextIndex;
+      while(0 <= inputTagCounter){
+        //hidden要素にはidに`hiddenCount${inputのインデックス番号}`が付けられている
+        let filledInputSelecter = "#hiddenCount" + inputTagCounter;
+          //lengthメソッドの返り値が0なら要素が存在しない
+        if ($(filledInputSelecter).length ==0){
+          //サムネイルの無い番号だったならその値へ更新
+          nextIndex = inputTagCounter;
+        }
+        inputTagCounter = inputTagCounter -1;
+      }
+    return nextIndex;
+  }
+  //labelのfor属性内の数値を返す、他所でも起動しているらしくDOMセレクタ見直し
+  //応急処置（たぶん）
+  function readLabelIndexCreate(){
+    let labelIndex = $('label').attr('for').replace(/[^0-9]/g, '');//数字でない部分を空白へ置換=削除
+    labelIndex = Number(labelIndex);//数値型へ変換
+    return labelIndex;
+  }
+  function overwriteLabel(inputIndex){
+    let updatedFor = 'product_product_images_attributes_'+inputIndex+'_product_image';
+    $("[for ^='product_product_images_attributes_']").attr('for', updatedFor);
+  }
+  //削除ボタンを押した時の処理///////発火しない、原因がわからない修理要//////
+  $(document).off('click');
+  $(document).on('click', '.added-img-delete-btn', function(e) {//なぜ$()->$(document)だといけたのか未理解
+    console.log('added-img-delete-btn was clicked');
+    e.preventDefault();
+    let btnBox =e.target.closest('.thumbnail__sub');
+    let inputHidden =$(btnBox).prev();
+    let imgThumbnail = $(inputHidden).prev();
+    let inputFile = $(inputHidden).prev();
+    $(inputFile).val(null); // TODO:アップロードされたファイルの削除 countをnull許可にすると途中で削除した画像も保存されてしまう
+    $(imgThumbnail).remove();
+    $(inputHidden).remove();
+    $(btnBox).remove();
+    labelIndex = youngestInputIndex();
+    overwriteLabel(labelIndex);
+    overwriteHiddenCountAll();
+  });
+  let labelIndex = readLabelIndexCreate(); //new.html.hamlで定義される"0"
+  $('.image-form').on('change', 'input[type="file"]', function(e) {
+    //inputタグのインデックスを取得する
+    labelIndex = readLabelIndexCreate();
+    // 11枚目なら中断
+    if(labelIndex >= 10){//inputタグで検出するのでダイアログは表示される
+      return false;
+    }
+    let file = e.target.files[0];
+    // 画像ファイル以外なら中断
+    if(file.type.indexOf("image") < 0){
+      return false;
+    }
+
+    //ファイルリーダーがファイルを読み終わったら行うサムネイル生成などの関連処理
+    //(関数として切り出すとサムネイルが表示されなくなったため保留//
+    //e.target.resultを変数に代入もできないためそのあたりの影響とかんがえられる)
+    let reader = new FileReader();
+    // let changedInput = $(e.target);
+    //を付与
+    reader.onload = function (e){
+      let imageThumbnail =`
+        <div class="product-img-box added-img">
+          <img src="${e.target.result}" width="114px" height="116px" 
+            class="thumbnail" title="${file.name}" >
+          <input type="hidden" 
+            name="product[product_images_attributes][${labelIndex}][count]" 
+            value="${labelIndex}"
+            id = "hiddenCount${labelIndex}"
+            class = "hiddenCount">
+          <div class="thumbnail__sub">
+            <div class="thumbnail__sub__btn">編集</div>
+            <div class="added-img-delete-btn thumbnail__sub__btn">削除</div>
+          </div>
+        </div>
+        `;
+      $('.create-dropbox__label').before(imageThumbnail);
+      $('.create-dropbox__label').ready(function(){ //  この記述でDOM要素読み込まれるまで待つらしい
+        //次のchangeイベントでのinputタグ(product_model)を更新
+        labelIndex = youngestInputIndex();
+        overwriteLabel(labelIndex);
+        overwriteHiddenCountAll();
+        //プレースホルダ非表示
+        $('.dropbox__placeholder').hide();
+        
+      });
+    };
+    ///ファイル読み込み 上記サムネイル・編集削除ボタン・count値のhidden input生成等が行われる
+    reader.readAsDataURL(file);
+    //サムネイルと編集削除ボタン生成ここまで//
+
+  });
+});

--- a/app/assets/javascripts/product_form_img.js
+++ b/app/assets/javascripts/product_form_img.js
@@ -34,12 +34,10 @@ $(document).on('turbolinks:load', function(){
     let nextIndex = $(allImgs).length;
     //10ならば最大枚数アップ済、labelが機能しなくなる値""を返す
     if (nextIndex == 10){
-      return "";//
+      return "";
     }
-    //0ならばプレースホルダを再表示し0を返す
-    //最後の1枚削除によりアップローダーが空になった場合
+    //0ならば0を返し終了
     else if(nextIndex ==0){
-      $('.dropbox__placeholder').show();
       return nextIndex;
     }
     //この時点でnextIndexは返り値の取りうる最大値
@@ -102,9 +100,6 @@ $(document).on('turbolinks:load', function(){
         labelIndex = youngestInputIndex();
         overwriteLabel(labelIndex);
         overwriteHiddenCountAll();
-        //プレースホルダ非表示
-        $('.dropbox__placeholder').hide();
-        
       });
     };
     ///ファイル読み込み 上記サムネイル・編集削除ボタン・count値のhidden input生成等が行われる

--- a/app/assets/javascripts/product_form_img.js
+++ b/app/assets/javascripts/product_form_img.js
@@ -1,5 +1,4 @@
 $(document).on('turbolinks:load', function(){
-  console.log('form');
     //hidden属性で送られるcountの値を今あるimgの連番で振り直し（途中のイメージを削除された時のため）
   //画像が何枚あるか何枚目かはこの値で管理
   function overwriteHiddenCountAll(){
@@ -110,8 +109,7 @@ $(document).on('turbolinks:load', function(){
 
   //削除ボタンを押した時の処理
   $(document).off('click');
-  $(document).on('click', '.added-img-delete-btn', function(e) {//なぜ$()->$(document)だといけたのか未理解
-    console.log('added-img-delete-btn was clicked');
+  $(document).on('click', '.added-img-delete-btn', function(e) {
     e.preventDefault();
     let productImgBox =e.target.closest('.added-img');
     let fileInputName = returnfileInputName(productImgBox);

--- a/app/assets/javascripts/search.js
+++ b/app/assets/javascripts/search.js
@@ -26,9 +26,9 @@ function appendCategory_g(ct){
   //////要素ごとのイベント応答群
   //画像サムネイルの削除ボタンを押した時の処理
   // $(document).off('click');//イベント多重化防止
-  // $(document).on('click', '.img-delete-btn', function(e) {//なぜ$()->$(document)だといけたのか未理解
+  // $(document).on('click', '.thumbnail__sub__btn', function(e) {//なぜ$()->$(document)だといけたのか未理解
   //   e.preventDefault();
-  //   let btnBox =e.target.closest('.btn-box');
+  //   let btnBox =e.target.closest('.thumbnail__sub');
   //   let inputHidden =$(btnBox).prev();
   //   let imgThumbnail = $(inputHidden).prev();
   //   let inputFile = $(inputHidden).prev();

--- a/app/assets/stylesheets/products/new.scss
+++ b/app/assets/stylesheets/products/new.scss
@@ -145,6 +145,9 @@ label {
     justify-content: flex-start;
     width: $dropbox-width;
     margin: 16px auto 0;
+    & input{
+      display: none;
+    }
     .product-img-box{
       background-color: $img-dropbox-color;
       margin-right: $thumbnail-horizontal-space;
@@ -155,20 +158,17 @@ label {
       &:nth-child(#{$thumbnails-per-row * 2}){
         margin-right: 0;
       }
-      & input{
-        display: none;
-      }
       & .thumbnail{
         object-fit: contain;
         border: 1px solid #eee;
       }
-      .btn-box {
+      .thumbnail__sub {
         width:114px;
         color: $thumbnail-text-color;
         display:flex;
         justify-content:space-between;
         color: 0099E8;
-        .img-edit-btn, .img-delete-btn{
+        .thumbnail__sub__btn {
           display:block;
           height: 44px;
           width: 50%;

--- a/app/assets/stylesheets/products/new.scss
+++ b/app/assets/stylesheets/products/new.scss
@@ -188,30 +188,9 @@ label {
       border: 1px dashed #ccc;
       background: $img-dropbox-color;
       cursor: pointer;
-      &:nth-child(5n+1) {
-        width: $product-image-form-width;
-      }
-      &:nth-child(5n+2) {
-        width: $product-image-form-width - ($img-thumbnail-width + $thumbnail-horizontal-space) * 1;
-      }
-      &:nth-child(5n+3) {
-        width: $product-image-form-width - ($img-thumbnail-width + $thumbnail-horizontal-space) * 2;
-      }
-      &:nth-child(5n+4) {
-        width: $product-image-form-width - ($img-thumbnail-width + $thumbnail-horizontal-space) * 3;
-      }
-      &:nth-child(5n) {
-        width: $product-image-form-width - ($img-thumbnail-width + $thumbnail-horizontal-space) * 4;
-      }
-      &:nth-child(n+11) {
-        display:none;
-      }
-      &::-webkit-scrollbar {
-        display: none;
-      }
       .dropbox__placeholder {
         position: absolute;
-        display: block;
+        // display: block;
         top: 50%;
         left: 16px;
         right: 16px;
@@ -226,6 +205,43 @@ label {
         pointer-events: none;
         white-space: pre-wrap;
         word-wrap: break-word;
+      }
+      &:nth-child(5n+1) {
+        width: $product-image-form-width;
+        .dropbox__placeholder {
+          position: absolute;
+          display: block;
+        }
+      }
+      &:nth-child(5n+2) {
+        width: $product-image-form-width - ($img-thumbnail-width + $thumbnail-horizontal-space) * 1;
+        .dropbox__placeholder {
+          display: none;
+        }
+      }
+      &:nth-child(5n+3) {
+        width: $product-image-form-width - ($img-thumbnail-width + $thumbnail-horizontal-space) * 2;
+        .dropbox__placeholder {
+          display: none;
+        }
+      }
+      &:nth-child(5n+4) {
+        width: $product-image-form-width - ($img-thumbnail-width + $thumbnail-horizontal-space) * 3;
+        .dropbox__placeholder {
+          display: none;
+        }
+      }
+      &:nth-child(5n) {
+        width: $product-image-form-width - ($img-thumbnail-width + $thumbnail-horizontal-space) * 4;
+        .dropbox__placeholder {
+          display: none;
+        }
+      }
+      &:nth-child(n+11) {
+        display:none;
+      }
+      &::-webkit-scrollbar {
+        display: none;
       }
     }
   }

--- a/app/views/products/edit.html.haml
+++ b/app/views/products/edit.html.haml
@@ -22,7 +22,7 @@
               .btn-box
                 .img-edit-btn
                   編集
-                .img-delete-btn
+                .exist-img-delete-btn.img-delete-btn
                   削除
         %label{for: "product_product_images_attributes_#{@exising_img_count}_product_image", class: "dropbox__label edit-dropbox__label"}
           %pre.dropbox__placeholder.dropbox__placeholder--edit

--- a/app/views/products/edit.html.haml
+++ b/app/views/products/edit.html.haml
@@ -19,10 +19,10 @@
               =image_tag("#{img.product_image}", width: "114px", height: "116px", class: "thumbnail") 
               %input{type: "hidden", name:"product[product_images_attributes][#{i}][id]", value: img.id}
               %input{type: "hidden", name:"product[product_images_attributes][#{i}][_destroy]", value: 0}
-              .btn-box
-                .img-edit-btn
+              .thumbnail__sub
+                .thumbnail__sub__btn
                   編集
-                .exist-img-delete-btn.img-delete-btn
+                .exist-img-delete-btn.thumbnail__sub__btn
                   削除
         %label{for: "product_product_images_attributes_#{@exising_img_count}_product_image", class: "dropbox__label edit-dropbox__label"}
           %pre.dropbox__placeholder.dropbox__placeholder--edit
@@ -31,8 +31,7 @@
               またはクリックしてファイルをアップロード
             %i.icon-camera{value: @product.id}
         =f.fields_for :product_images do |img|
-          .product-img-box.added-img
-            =img.file_field :product_image #cssで非表示（削除方法）
+          =img.file_field :product_image #cssで非表示（削除方法）
     .form-section{id: @user.id, value: @product.id}
       .form-input
         %label.form-input__title

--- a/app/views/products/new.html.haml
+++ b/app/views/products/new.html.haml
@@ -20,8 +20,7 @@
               またはクリックしてファイルをアップロード
             -# %i.icon-camera 表示できない 余裕あればウインドウ幅が狭くなった際テキストの代わりに表示
           =f.fields_for :product_images do |img|
-            .product-img-box.added-img
-              =img.file_field :product_image #cssで非表示（削除方法）
+            =img.file_field :product_image #cssで非表示（削除方法）
     .form-section{id: @user.id}
       .form-input
         %label.form-input__title


### PR DESCRIPTION
コンフリクトは無いためマージいたします

サムネイルの削除ボタンの動作を直しました、これで新規出品フォームの画像部分の機能は揃ったと思います
なおeditフォームの画像部分については干渉含め明日以降見直します。。

また、新規出品フォーム（product_create.js）の商品画像処理を、product_form_img.jsとしてファイル分離しました
きっかけは修正中$(documnt).on('turbolinks:load'~内だと画像選択部分が正常に働いてくれないように見えたため（このこと自体は勘違いでした）なのですが、量が増えてきて見づらくなっていたのが改善できたので問題なければこのままいかせてください。